### PR TITLE
fix: use bash agnostic syntax

### DIFF
--- a/src/log_helpers.sh
+++ b/src/log_helpers.sh
@@ -21,7 +21,7 @@ function _log_x() {
 			lines="$2"
 		fi
 	else
-		prefix="[${1^^}]"
+		prefix="[$(echo "$1" | tr '[:lower:]' '[:upper:]')]"
 
 		if [[ -n "$3" ]]; then
 			prefix="$prefix ${2}: "


### PR DESCRIPTION
This line didn't work in zsh